### PR TITLE
chore: add tls block to ingress manifest

### DIFF
--- a/k8s/manifest.yml
+++ b/k8s/manifest.yml
@@ -81,6 +81,10 @@ metadata:
   annotations:
     kubernetes.io/ingress.class: nginx
 spec:
+  tls:
+  - hosts:
+    - #{Host}#
+    secretName: remote-falcon-tls
   rules:
   - host: #{Host}#
     http:


### PR DESCRIPTION
## Summary

Adds a `tls:` block to the Ingress in `k8s/manifest.yml` so `kubectl apply` preserves the `remote-falcon-tls` Secret (Cloudflare Origin Certificate) installed during the 2026-05-02 Cloudflare Full (Strict) cutover.

Without this, any `workflow_dispatch` (or push to `main`) re-applies the manifest, **strips the live `tls:` block off the Ingress**, ingress-nginx falls back to the placeholder `Acme Co Kubernetes Ingress Controller Fake Certificate`, and Cloudflare returns `526` to all users of this service until the patch is reapplied.

The cert and key themselves are not in git — they remain only in the `remote-falcon-tls` Secret in the cluster, created out-of-band.

## Test plan
- [ ] After merge, run `workflow_dispatch` and confirm the rendered manifest in CI logs has the `tls:` block populated (`#{Host}#` → `remotefalcon.com`).
- [ ] After rollout, `kubectl describe ingress -n remote-falcon` shows the `tls:` section preserved.
- [ ] Browse to the public URL and confirm the served cert is the Cloudflare Origin Certificate, not the Acme placeholder.

Refs: Remote-Falcon/remote-falcon-issue-tracker#115